### PR TITLE
Some CSS improvements and fix broken image

### DIFF
--- a/reviewington/static/css/index.css
+++ b/reviewington/static/css/index.css
@@ -1,3 +1,8 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
+    sans-serif, Apple Color Emoji, Segoe UI Emoji;
+}
+
 .button {
   background-color: #a9a9a9;
   border: 1px solid #888888;
@@ -379,8 +384,6 @@ h1 {
   -webkit-text-size-adjust: 100%;
   line-height: 1.5;
   color: #24292e;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji;
   font-size: 16px;
   line-height: 1.5;
   word-wrap: break-word;
@@ -428,8 +431,6 @@ h1 {
   border: solid #dadada;
   border-width: 1px;
   border-radius: 6px;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
-    sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
 .discussion .file-header {

--- a/reviewington/templates/home.html
+++ b/reviewington/templates/home.html
@@ -27,7 +27,7 @@
       <!-- TODO: Replace gif with image-->
       <img
         src="{{url_for('static', filename='img/Reviewington.png')}}"
-        style="display: block; margin: 0 auto"
+        style="display: block; margin: 0 auto; width: 300px"
       />
       <h1 style="text-align: center; font-size: 40px">Reviewington</h1>
       <div style="margin-left: auto; margin-right: auto">

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "reviewington": [
             "templates/*",
             "static/css/*",
+            "static/img/*",
             "about.txt",
             "github_action_template/*",
         ],


### PR DESCRIPTION
The Reviewington logo wasn't showing on the home page when using `rton`. This PR fixes that issue, and includes a couple small CSS improvements.

NB: in order for the change to take effect, I had to uninstall `reviewington` via `pip3`, re-build the package, then reinstall.